### PR TITLE
Fix: Reduce space between banner and title on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,8 +645,7 @@
         /* Espaçamento adicional para mobile */
         @media (max-width: 768px) {
             .products {
-                margin-top: 0;
-                padding-top: 0;
+                margin-top: -2rem;
             }
             
             .products .section-header {


### PR DESCRIPTION
Reduces the vertical space between the mobile banner and the "Produtos e Serviços" section.

This is achieved by applying a negative `margin-top` to the `.products` section within a media query for mobile screen sizes. This pulls the section up, ensuring the title appears directly after the banner without overlapping.